### PR TITLE
Change speech at COSCUP to the correct year

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -436,7 +436,7 @@
                     <ul>
                         <li>
                             <a href="https://coscup.org/"
-                                >COSCUP 2025 - The Path to Freedom: The Open
+                                >COSCUP 2024 - The Path to Freedom: The Open
                                 Source Journey of SCAICT</a
                             >
                         </li>

--- a/zh-Hant/about/index.html
+++ b/zh-Hant/about/index.html
@@ -435,7 +435,7 @@
                     <ul>
                         <li>
                             <a href="https://coscup.org/"
-                                >COSCUP 2025 - 前往自由的路上:
+                                >COSCUP 2024 - 前往自由的路上:
                                 中電喵的開源之旅</a
                             >
                         </li>


### PR DESCRIPTION
《前往自由的路上 - 中電喵的開源之旅》是 [COSCUP 2024 的議程](https://coscup.org/2024/zh-TW/session/KZ9VBD)，所以我把 2025 改成 2024 了。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated COSCUP event year from 2025 to 2024 in both English and Traditional Chinese about pages
	- Corrected event hyperlink text to reflect the current year
<!-- end of auto-generated comment: release notes by coderabbit.ai -->